### PR TITLE
Fixed known bugs

### DIFF
--- a/app/_services/notes-service.ts
+++ b/app/_services/notes-service.ts
@@ -28,9 +28,7 @@ export async function getNotes(user : User)
         querySnapshot.forEach((doc) => {
 
             let data = doc.data(); 
-            if(data.folder === ""){
-                notes.push(
-
+            notes.push(
                     {
                         id: doc.id, 
                         title: data.title,
@@ -39,20 +37,9 @@ export async function getNotes(user : User)
                         folder: data.folder
                     }
                 );
-            }else{
-                notes.push(
-
-                    {
-                        id: doc.id, 
-                        title: data.title,
-                        content: data.content,
-                        date: data.date.toDate(),
-                    }
-                ); 
-            }
    
         });
-        console.log("reading from Firestore");
+        console.log("reading from FireBase at getNotes");
     }
     catch(ex : any){
         console.log(ex); 
@@ -68,24 +55,15 @@ export async function updateNote(user: User, note: Note){
     {
         const docRef = doc(db, "users", user.uid, "notes", note.id); 
         try{
-            if(note.folder === ""){
                 await updateDoc(docRef, {
                     title: note.title,
                     content: note.content,
                     date: note.date,
                     folder: note.folder
                 }); 
-            }else{
-                updateDoc(docRef, {
-                    title: note.title,
-                    content: note.content,
-                    date: note.date,
-                    folder: deleteField()
-                });
-            }
-            console.log("reading from Firestore");
-        }
-        catch(ex :any){
+        
+                console.log("writing to FireBase at updateNote");
+            }catch(ex :any){
             console.log(ex); 
         }
     }
@@ -99,7 +77,7 @@ export async function createNote(user: User, note: Note)
             note
             
         )
-        console.log("reading from Firestore");
+        console.log("writing to FireBase at createNote");
         return docRef?.id;
     }
     catch(ex : any){
@@ -112,7 +90,7 @@ export async function deleteNote(user:User, note:Note) {
     try{
         const docRef = doc(db, "users", user.uid, "notes", note.id);
         await deleteDoc(docRef);
-        console.log("reading from Firestore");
+        console.log("writing to FireStore at deleteNote");
     }
     catch(ex :any)
     {
@@ -148,12 +126,12 @@ export async function createFolder(user: User, folder: Folder)
             collection(db, "users", user.uid, "folders"),
             folder
         )
+        console.log("writing to FireBase at createFolder");
         return docRef?.id;
     }
     catch(ex : any){
         console.log(ex);
     }
-    console.log("reading from Firestore");
 }
 
 export async function getFolders(user : User)
@@ -176,7 +154,7 @@ export async function getFolders(user : User)
                 }
             );
         });
-        console.log("reading from Firestore");
+        console.log("reading from FireStore at getFolders");
     }
     catch(ex : any){
         console.log(ex); 
@@ -199,7 +177,7 @@ export async function deleteFolder(user:User, folder:Folder) {
         querySnapshot.forEach(async (document) => await updateDoc(doc(db, "users", user.uid, "notes", document.id), {
             folder: deleteField()
         })); 
-        console.log("reading from Firestore");
+        console.log("writing to FireStore at deleteFolder");
     }
     catch(ex :any)
     {
@@ -215,7 +193,7 @@ export async function updateFolder(user: User, folder: Folder){
             await updateDoc(docRef, {
                 name: folder.name
             }); 
-            console.log("reading from Firestore");
+            console.log("writing to FireStore at updateFolder");
         }
         catch(ex :any){
             console.log(ex); 
@@ -227,7 +205,7 @@ export async function deleteAccountContents(user:User) {
     try{
         const docRef = doc(db, "users", user.uid);
         await deleteDoc(docRef);
-        console.log("reading from Firestore");
+        console.log("writing to FireStore at deleteAccountContents");
     }
     catch(ex :any)
     {

--- a/app/_utils/note-context.js
+++ b/app/_utils/note-context.js
@@ -10,6 +10,7 @@ const NotesContext = createContext();
 export function NoteContextProvider({children}){
     const [notes, setNotes] = useState([]); 
     const [originalNotes, setOriginalNotes] = useState([]); 
+    const {selectedFolder} = useFoldersContext();
     const [viewedNote, setViewedNote] = useState(null);
     const [filter, setFilter] = useState(false); 
     const {user} = useUserAuth(); 
@@ -63,11 +64,11 @@ export function NoteContextProvider({children}){
 
     function endFilter(folder=null){
         setViewedNote(null);
-        setFilter(false); 
         if(folder){
             setNotes(originalNotes.filter((note) => note.folder == folder.id))
         }
         else{
+            setFilter(false);
             setNotes(originalNotes); 
         }
     }
@@ -81,7 +82,12 @@ export function NoteContextProvider({children}){
 
     useEffect(
         () => {
-            setNotes(originalNotes);
+            if(filter && selectedFolder){
+                setNotes(originalNotes.filter((note) => note.folder === selectedFolder.id));
+            }else{
+                setNotes(originalNotes);
+            }
+            
         },
         [originalNotes]
     )

--- a/app/components/UI/NoteViewer.tsx
+++ b/app/components/UI/NoteViewer.tsx
@@ -20,7 +20,7 @@ function NoteViewer({ display, handleDeleteNote }: Props) {
   const [title, setTitle] = useState("");
   const [content, setContent] = useState("");
   const [date, setDate] = useState(new Date());
-  const [folder, setFolder]: [string, Function] = useState("");
+  const [folder, setFolder]: [string | null, Function] = useState("");
   const {folders, selectedFolder} = useFoldersContext(); 
   const { user } = useUserAuth();
   const { handleAddNote} = useNotesContext();


### PR DESCRIPTION
1. Fixed bug where notes could not be added to FireStore if their folder field is an empty string
2. Fixed bug where a selected folder would stop filtering if a new note is added
3. Fixed issue where folders can no longer filter notes in general 
5. Verified: No updates were written to FireStore if a note is "saved" to deselect it 
6. Discovered and resolved issue where when filtering by folders and a search is conducted, immediately followed by a folder switch, folder filtering would fail. 
     Cause: "EndFilter" would be called with a folder passed to maintain folder filtering when search is ended. This would call "setNote" with originalNotes filtered with the provided folder. When calling "filterByFolder"  immediately without another "endFilter" with no folder param, "filterByFolder" would work on the current notes (originalNotes filtered by the first folder) resulting in no folders. 

    Fix: when a folder is passed to "endFilter" the "filter" state would not be set to false so that handleFilterByFolder would work on "originalNotes" instead of "notes if it is called subsequently without intervening "endFilter" call. 